### PR TITLE
Generate space for buildings

### DIFF
--- a/src/City.elm
+++ b/src/City.elm
@@ -1,4 +1,4 @@
-module City exposing (Budget, City, changeBudget, generate, init, initialBudget, visualization)
+module City exposing (Budget, City, CityTile, changeBudget, generate, init, initialBudget, visualization)
 
 import City.Building as Building exposing (BuildingType(..))
 import City.Education as Education
@@ -26,6 +26,11 @@ type alias City =
     }
 
 
+type CityTile
+    = Connecting Road
+    | EmptyPlot
+
+
 init :
     { parks : Int
     , housing : Int
@@ -42,40 +47,43 @@ initialBudget =
 
 
 cityWidth =
-    6
+    8
 
 
 cityHeight =
-    6
+    8
 
 
-generate : Seed -> ( Board Road, Seed )
+generate : Seed -> ( Board CityTile, Seed )
 generate seed =
     Tiler.generateBoard cityWidth cityHeight generateOneOf validateNeighbors seed
 
 
-generateOneOf : ( Int, Int ) -> ( Road, List Road )
+generateOneOf : ( Int, Int ) -> ( CityTile, List CityTile )
 generateOneOf _ =
-    ( Road Straight RNone
-    , [ Road Straight RQuarter
-      , Road Corner RNone
-      , Road Corner RQuarter
-      , Road Corner RHalf
-      , Road Corner RThreeQuarters
-      , Road Junction RNone
-      , Road Tee RNone
-      , Road Tee RQuarter
-      , Road Tee RHalf
-      , Road Tee RThreeQuarters
+    ( Connecting (Road Straight RNone)
+    , [ Connecting (Road Straight RQuarter)
+      , Connecting (Road Corner RNone)
+      , Connecting (Road Corner RQuarter)
+      , Connecting (Road Corner RHalf)
+      , Connecting (Road Corner RThreeQuarters)
+      , Connecting (Road Junction RNone)
+      , Connecting (Road Tee RNone)
+      , Connecting (Road Tee RQuarter)
+      , Connecting (Road Tee RHalf)
+      , Connecting (Road Tee RThreeQuarters)
+      , EmptyPlot
+      , EmptyPlot
+      , EmptyPlot
       ]
     )
 
 
-validateNeighbors : List Road -> List Road -> Neighbor -> ( Road, List Road )
+validateNeighbors : List CityTile -> List CityTile -> Neighbor -> ( CityTile, List CityTile )
 validateNeighbors possibleThisTiles possibleNeighbors neighborDirection =
     let
         filteredPossibilities =
-            List.filter (\neigh -> List.any (\self -> validJunction neighborDirection self neigh) possibleThisTiles) possibleNeighbors
+            List.filter (\neigh -> List.any (\self -> validTile neighborDirection self neigh) possibleThisTiles) possibleNeighbors
     in
     case filteredPossibilities of
         t :: others ->
@@ -83,7 +91,238 @@ validateNeighbors possibleThisTiles possibleNeighbors neighborDirection =
 
         [] ->
             -- TODO: Find a way to never reach this
-            ( Road Straight RNone, [] )
+            ( EmptyPlot, [] )
+
+
+flipDirection direction =
+    case direction of
+        North ->
+            South
+
+        West ->
+            East
+
+        South ->
+            North
+
+        East ->
+            West
+
+
+validPlot : Neighbor -> Road -> Bool
+validPlot neighborDirection road =
+    case ( road.style, road.rotation, neighborDirection ) of
+        ( Straight, RNone, North ) ->
+            True
+
+        ( Straight, RHalf, North ) ->
+            True
+
+        ( Straight, RQuarter, North ) ->
+            False
+
+        ( Straight, RThreeQuarters, North ) ->
+            False
+
+        ( Straight, RNone, South ) ->
+            True
+
+        ( Straight, RHalf, South ) ->
+            True
+
+        ( Straight, RQuarter, South ) ->
+            False
+
+        ( Straight, RThreeQuarters, South ) ->
+            False
+
+        ( Straight, RNone, West ) ->
+            False
+
+        ( Straight, RHalf, West ) ->
+            False
+
+        ( Straight, RQuarter, West ) ->
+            True
+
+        ( Straight, RThreeQuarters, West ) ->
+            True
+
+        ( Straight, RNone, East ) ->
+            False
+
+        ( Straight, RHalf, East ) ->
+            False
+
+        ( Straight, RQuarter, East ) ->
+            True
+
+        ( Straight, RThreeQuarters, East ) ->
+            True
+
+        ( Corner, RNone, North ) ->
+            False
+
+        ( Corner, RHalf, North ) ->
+            True
+
+        ( Corner, RQuarter, North ) ->
+            True
+
+        ( Corner, RThreeQuarters, North ) ->
+            False
+
+        ( Corner, RNone, South ) ->
+            True
+
+        ( Corner, RHalf, South ) ->
+            False
+
+        ( Corner, RQuarter, South ) ->
+            False
+
+        ( Corner, RThreeQuarters, South ) ->
+            True
+
+        ( Corner, RNone, West ) ->
+            False
+
+        ( Corner, RHalf, West ) ->
+            True
+
+        ( Corner, RQuarter, West ) ->
+            False
+
+        ( Corner, RThreeQuarters, West ) ->
+            True
+
+        ( Corner, RNone, East ) ->
+            True
+
+        ( Corner, RHalf, East ) ->
+            False
+
+        ( Corner, RQuarter, East ) ->
+            True
+
+        ( Corner, RThreeQuarters, East ) ->
+            False
+
+        ( Junction, RNone, North ) ->
+            False
+
+        ( Junction, RHalf, North ) ->
+            False
+
+        ( Junction, RQuarter, North ) ->
+            False
+
+        ( Junction, RThreeQuarters, North ) ->
+            False
+
+        ( Junction, RNone, South ) ->
+            False
+
+        ( Junction, RHalf, South ) ->
+            False
+
+        ( Junction, RQuarter, South ) ->
+            False
+
+        ( Junction, RThreeQuarters, South ) ->
+            False
+
+        ( Junction, RNone, West ) ->
+            False
+
+        ( Junction, RHalf, West ) ->
+            False
+
+        ( Junction, RQuarter, West ) ->
+            False
+
+        ( Junction, RThreeQuarters, West ) ->
+            False
+
+        ( Junction, RNone, East ) ->
+            False
+
+        ( Junction, RHalf, East ) ->
+            False
+
+        ( Junction, RQuarter, East ) ->
+            False
+
+        ( Junction, RThreeQuarters, East ) ->
+            False
+
+        ( Tee, RNone, North ) ->
+            False
+
+        ( Tee, RHalf, North ) ->
+            False
+
+        ( Tee, RQuarter, North ) ->
+            True
+
+        ( Tee, RThreeQuarters, North ) ->
+            False
+
+        ( Tee, RNone, South ) ->
+            False
+
+        ( Tee, RHalf, South ) ->
+            False
+
+        ( Tee, RQuarter, South ) ->
+            False
+
+        ( Tee, RThreeQuarters, South ) ->
+            True
+
+        ( Tee, RNone, West ) ->
+            False
+
+        ( Tee, RHalf, West ) ->
+            True
+
+        ( Tee, RQuarter, West ) ->
+            True
+
+        ( Tee, RThreeQuarters, West ) ->
+            False
+
+        ( Tee, RNone, East ) ->
+            True
+
+        ( Tee, RHalf, East ) ->
+            False
+
+        ( Tee, RQuarter, East ) ->
+            False
+
+        ( Tee, RThreeQuarters, East ) ->
+            False
+
+
+validTile : Neighbor -> CityTile -> CityTile -> Bool
+validTile neighborDirection self neighbor =
+    case ( self, neighborDirection ) of
+        ( Connecting road, _ ) ->
+            case neighbor of
+                Connecting neighborRoad ->
+                    validJunction neighborDirection road neighborRoad
+
+                EmptyPlot ->
+                    validPlot neighborDirection road
+
+        ( EmptyPlot, _ ) ->
+            case neighbor of
+                Connecting neighborRoad ->
+                    validPlot (flipDirection neighborDirection) neighborRoad
+
+                EmptyPlot ->
+                    True
 
 
 validJunction : Neighbor -> Road -> Road -> Bool
@@ -1822,13 +2061,23 @@ viewTile tile tileType =
             Tile.blank tile
 
 
-drawRoad : ( Int, Int ) -> Road -> Svg msg
-drawRoad ( x, y ) { style, rotation } =
-    let
-        tile =
-            Tile.default ( x, y ) rotation
-    in
+drawRoad : Tile -> Road -> Svg msg
+drawRoad tile { style } =
     Road.view tile style
+
+
+drawCityTile : ( Int, Int ) -> CityTile -> Svg msg
+drawCityTile ( x, y ) cityTile =
+    case cityTile of
+        EmptyPlot ->
+            Tile.blank (Tile.default ( x, y ) RNone)
+
+        Connecting ({ rotation } as road) ->
+            let
+                tile =
+                    Tile.default ( x, y ) rotation
+            in
+            drawRoad tile road
 
 
 drawUndecided : ( Int, Int ) -> String -> Svg msg
@@ -1836,36 +2085,43 @@ drawUndecided position style =
     Tile.blank (Tile.default position RNone)
 
 
-cellStyleToString : RoadType -> String
-cellStyleToString style =
-    case style of
-        Straight ->
-            "Straight"
+cityTileToString : CityTile -> String
+cityTileToString cityTile =
+    case cityTile of
+        EmptyPlot ->
+            "Empty Plot"
 
-        Junction ->
-            "Junction"
+        Connecting { style } ->
+            case style of
+                Straight ->
+                    "Straight"
 
-        Tee ->
-            "Tee"
+                Junction ->
+                    "Junction"
 
-        Corner ->
-            "Corner"
+                Tee ->
+                    "Tee"
 
-        --Crosswalk ->
-            --"Crosswalk"
+                Corner ->
+                    "Corner"
 
 
-drawTile : ( Int, Int ) -> ( Road, List Road ) -> Svg msg
-drawTile pos ( road, roads ) =
-    case roads of
+
+--Crosswalk ->
+--"Crosswalk"
+
+
+drawTile : ( Int, Int ) -> ( CityTile, List CityTile ) -> Svg msg
+drawTile pos ( cityTile, cityTiles ) =
+    case cityTiles of
         [] ->
-            drawRoad pos road
+            drawCityTile pos cityTile
 
         _ ->
-            drawUndecided pos (String.join "\n" (List.map (\{ style } -> cellStyleToString style) (road :: roads)))
+            drawUndecided pos (String.join "\n" (List.map cityTileToString (cityTile :: cityTiles)))
 
 
-visualization : Board Road -> City -> Element msg
+visualization : Board CityTile -> City -> Element msg
 visualization board city =
     Element.column [ Element.centerX ]
         [ Element.el [ Element.width shrink, Element.height shrink ]

--- a/src/City.elm
+++ b/src/City.elm
@@ -47,11 +47,11 @@ initialBudget =
 
 
 cityWidth =
-    8
+    15
 
 
 cityHeight =
-    8
+    15
 
 
 generate : Seed -> ( Board CityTile, Seed )
@@ -72,6 +72,10 @@ generateOneOf _ =
       , Connecting (Road Tee RQuarter)
       , Connecting (Road Tee RHalf)
       , Connecting (Road Tee RThreeQuarters)
+      , EmptyPlot
+      , EmptyPlot
+      , EmptyPlot
+      , EmptyPlot
       , EmptyPlot
       , EmptyPlot
       , EmptyPlot
@@ -2070,6 +2074,7 @@ drawCityTile : ( Int, Int ) -> CityTile -> Svg msg
 drawCityTile ( x, y ) cityTile =
     case cityTile of
         EmptyPlot ->
+            -- Housing.view { width = 90, height = 90, rotation = RNone, x = x - 1, y = y - 1 } (TallApartment 0)
             Tile.blank (Tile.default ( x, y ) RNone)
 
         Connecting ({ rotation } as road) ->

--- a/src/City/Road.elm
+++ b/src/City/Road.elm
@@ -10,7 +10,10 @@ type RoadType
     | Tee -- West <-> North <-> South intersection
     | Junction -- 4 way intersection
     | Straight --  West <-> East
-    --| Crosswalk -- West <-> East with a crosswalk
+
+
+
+--| Crosswalk -- West <-> East with a crosswalk
 
 
 type alias Road =
@@ -61,8 +64,10 @@ view tile roadType =
             else
                 straight tile
 
-        --Crosswalk ->
-            --crosswalk tile   --todo: add crosswalk alt
+
+
+--Crosswalk ->
+--crosswalk tile   --todo: add crosswalk alt
 
 
 threeWayIntersection : Tile -> Svg msg
@@ -219,6 +224,7 @@ crosswalk tile =
         , path [ fill "#fff", d "M26.56 25.886l1.705-1.255-8.467-5.47-1.704 1.254 8.467 5.47M29.132 24.148l1.704-1.255-8.466-5.47-1.704 1.253 8.466 5.472M31.648 22.661l1.704-1.254-8.47-5.47-1.705 1.253 8.47 5.471M34.22 21.007l1.703-1.255-8.47-5.47-1.704 1.254 8.47 5.47M36.629 19.525l1.704-1.254-8.47-5.47-1.704 1.253 8.47 5.471M39.003 17.935l1.704-1.255-8.467-5.47-1.704 1.254 8.467 5.47" ]
             []
         ]
+
 
 
 --todo: add crosswalk alt

--- a/src/City/Tile.elm
+++ b/src/City/Tile.elm
@@ -22,8 +22,8 @@ type Rotation
 
 default : ( Int, Int ) -> Rotation -> Tile
 default ( x, y ) rotation =
-    { height = 200
-    , width = 200
+    { height = 100
+    , width = 100
     , rotation = rotation
     , x = x
     , y = y
@@ -48,22 +48,22 @@ attrs tile =
                     -180
 
         ( originX, originY ) =
-            ( 7, 1 )
+            ( 16, 1 )
 
         ( x, y ) =
             ( tile.x + originX - tile.y, tile.y + originY + tile.x )
 
         midX =
-            (x * 95) + (tile.width // 2)
+            (toFloat x * 95 / 2) + toFloat (tile.width // 2)
 
         midY =
-            (y * 60) + (tile.height // 2)
+            (toFloat y * 60 / 2) + toFloat (tile.height // 2)
     in
     [ Attr.width (String.fromInt tile.width)
     , Attr.height (String.fromInt tile.height)
-    , Attr.x (String.fromFloat <| (toFloat x * 95))
-    , Attr.y (String.fromFloat <| (toFloat y * 60))
-    , transform ("rotate(" ++ String.fromInt rotInDeg ++ " " ++ String.fromInt midX ++ " " ++ String.fromInt midY ++ ")")
+    , Attr.x (String.fromFloat <| (toFloat x * 95 / 2))
+    , Attr.y (String.fromFloat <| (toFloat y * 60 / 2))
+    , transform ("rotate(" ++ String.fromInt rotInDeg ++ " " ++ String.fromFloat midX ++ " " ++ String.fromFloat midY ++ ")")
     ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,7 @@ module Main exposing (main)
 
 import Browser exposing (Document)
 import Browser.Events exposing (onAnimationFrameDelta)
-import City exposing (City)
+import City exposing (City, CityTile)
 import City.Road exposing (Road, RoadType(..))
 import Color
 import Data.Author as Author
@@ -132,7 +132,7 @@ type alias Model =
     { city : City
     , budget : City.Budget
     , randomSeed : Seed
-    , board : Board Road
+    , board : Board CityTile
     }
 
 


### PR DESCRIPTION
This doesn't really work well until the algorithm is changed to generate blocks instead of mazes.

Until then, we've got some blank spaces for parks and building.

Next up: how to fill in the gaps deterministically?

Current thoughts on approach:

The Board is just a `Dict`. I could `map` over the dict to get all the blank tile positions, and then collect those into some data structure. We'll reconcile the data structure and the current city budget. The output will be tuples of the blank tile positions and their assigned plot. Then, we'll do a `Dict.update position (Plot assignedTile)` every time a slider is moved. Something like that. i'm sure there's bugs in that model.